### PR TITLE
test: simplify vitest config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
 		projects: [
 			{
 				// Client-side tests (Svelte components)
-				extends: './vite.config.ts',
+				extends: true,
 				test: {
 					name: 'client',
 					environment: 'browser',
@@ -35,7 +35,7 @@ export default defineConfig({
 			},
 			{
 				// SSR tests (Server-side rendering)
-				extends: './vite.config.ts',
+				extends: true,
 				test: {
 					name: 'ssr',
 					environment: 'node',
@@ -44,7 +44,7 @@ export default defineConfig({
 			},
 			{
 				// Server-side tests (Node.js utilities)
-				extends: './vite.config.ts',
+				extends: true,
 				test: {
 					name: 'server',
 					environment: 'node',
@@ -60,20 +60,12 @@ export default defineConfig({
 			all: true,
 			reporter: ['text-summary', 'html'],
 			provider: 'v8',
+			include: ['src'],
 			exclude: [
 				...coverageConfigDefaults.exclude,
-				'**/config.{js,ts,cjs}',
-				'**/*.config.{js,ts,cjs}',
 				'**/+page.svelte',
 				'**/+layout.svelte',
 				'**/+error.svelte',
-				'.svelte-kit/**',
-				'build/**',
-				'static/**',
-				'dist/**',
-				'coverage/**',
-				'**/*.d.ts',
-				'**/types/**',
 			],
 			thresholds: {
 				statements: 50,


### PR DESCRIPTION
Simplifies Vitest setup.

- `extends: true` automatically inherits the configuration from the same file
- using `coverage.include` improves performance as Vitest doesn't need to check unrelated files